### PR TITLE
add support for longer LNURLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ lnurl = Lnurl.decode('LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJ7URP0YVM59LW')
 lnurl.uri # => #<URI::HTTPS https://lnurl.com/pay>
 ```
 
-For longer LNURLs you might see an error while decoding, in that case you can use
+By default we accept long LNURLs but you can configure a custom max length:
 ```ruby
-lnurl = Lnurl.decode(a_very_long_lnurl, Lnurl::MAX_INTEGER)
+lnurl = Lnurl.decode(a_short_lnurl, 90)
 ```
 
 ### [Lightning Address](https://github.com/andrerfneves/lightning-address)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ lnurl.uri # => #<URI::HTTPS https://lnurl.com/pay>
 
 For longer LNURLs you might see an error while decoding, in that case you can use
 ```ruby
-lnurl = Lnurl.decode(a_very_long_lnurl, Lnurl::FIXNUM_MAX)
+lnurl = Lnurl.decode(a_very_long_lnurl, Lnurl::MAX_INTEGER)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ lnurl = Lnurl.decode('LNURL1DP68GURN8GHJ7MRWW4EXCTNRDAKJ7URP0YVM59LW')
 lnurl.uri # => #<URI::HTTPS https://lnurl.com/pay>
 ```
 
+For longer LNURLs you might see an error while decoding, in that case you can use
+```ruby
+lnurl = Lnurl.decode(a_very_long_lnurl, Lnurl::FIXNUM_MAX)
+```
+
+
 ### LNURL responses
 
 ```ruby

--- a/lib/lnurl.rb
+++ b/lib/lnurl.rb
@@ -6,6 +6,10 @@ require 'ostruct'
 class Lnurl
   VERSION = '1.0.1'.freeze
 
+  # Maximum integer size
+  # Useful for max_length when decoding
+  FIXNUM_MAX = (2**(0.size * 8 -2) -1)
+
   InvoiceResponse = Class.new(OpenStruct)
   LnurlResponse = Class.new(OpenStruct) do
     # amount in msats
@@ -61,13 +65,13 @@ class Lnurl
     return decoded.match?(URI.regexp) # check if the URI is valid
   end
 
-  def self.decode(lnurl)
-    Lnurl.new(decode_raw(lnurl))
+  def self.decode(lnurl, max_length = 90)
+    Lnurl.new(decode_raw(lnurl, max_length))
   end
 
-  def self.decode_raw(lnurl)
+  def self.decode_raw(lnurl, max_length = 90)
     lnurl = lnurl.gsub(/^lightning:/, '')
-    hrp, data, sepc = Bech32.decode(lnurl)
+    hrp, data, sepc = Bech32.decode(lnurl,max_length)
     # raise 'no lnurl' if hrp != HRP
     convert_bits(data, 5, 8, false).pack('C*').force_encoding('utf-8')
   end

--- a/lib/lnurl.rb
+++ b/lib/lnurl.rb
@@ -8,7 +8,7 @@ class Lnurl
 
   # Maximum integer size
   # Useful for max_length when decoding
-  FIXNUM_MAX = (2**(0.size * 8 -2) -1)
+  MAX_INTEGER = 2**31 - 1
 
   InvoiceResponse = Class.new(OpenStruct)
   LnurlResponse = Class.new(OpenStruct) do

--- a/lib/lnurl.rb
+++ b/lib/lnurl.rb
@@ -65,13 +65,13 @@ class Lnurl
     return decoded.match?(URI.regexp) # check if the URI is valid
   end
 
-  def self.decode(lnurl, max_length = 90)
+  def self.decode(lnurl, max_length = MAX_INTEGER)
     Lnurl.new(decode_raw(lnurl, max_length))
   end
 
-  def self.decode_raw(lnurl, max_length = 90)
+  def self.decode_raw(lnurl, max_length = MAX_INTEGER)
     lnurl = lnurl.gsub(/^lightning:/, '')
-    hrp, data, sepc = Bech32.decode(lnurl,max_length)
+    hrp, data, sepc = Bech32.decode(lnurl, max_length)
     # raise 'no lnurl' if hrp != HRP
     convert_bits(data, 5, 8, false).pack('C*').force_encoding('utf-8')
   end


### PR DESCRIPTION
`.decode` Wasn't working with Wallet of Satoshi URLs

This https://github.com/azuchi/bech32rb/tree/master#advanced seems to resolve the issue